### PR TITLE
Update Configuration.php

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,6 +32,6 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('retryAttempts')->defaultValue(1)->end()
             ->end();
 
-        return $treeBuilder->buildTree();
+        return $treeBuilder;
     }
 }


### PR DESCRIPTION
Should return $treeBuilder instead of $treeBuilder->buildTree().  You can see the error when you do a php app/console config:dump-reference vresh_twilio, it will error out in its present state.  All other bundles Symfony uses simply return $treeBuilder.
