### PR TITLE
Lock twilio sdk version to <5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=5.3.2",
     "symfony/framework-bundle": "~2.1|~3.0",
-    "twilio/sdk": ">=4.0.2"
+    "twilio/sdk": ">=4.0.2 <5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.1",


### PR DESCRIPTION
Twilio recently released a new major version which breaks the bundle.  Locking this version down to <5.0 prevents the bundle from breaking.
